### PR TITLE
fix: redirect to stdout

### DIFF
--- a/watchman.sh
+++ b/watchman.sh
@@ -252,7 +252,7 @@ $inotify_cmd | while read key; do
         _status="$?"
 
         if [ "$_status" == "0" ]; then
-            success "Success!" >&2
+            success "Success!" >&1
         else
             if [[ "$bell_on_error" ]]; then
                 error "\a" >&2


### PR DESCRIPTION
The success output should be redirected to `stdout` rather than `stderr` since it's not exactly an error...

btw I love this project... I am learning shell scripting right now and this is helping a lot.. also being able to understand the usage of makefiles as well... 👍🏼  